### PR TITLE
Added 'locals' option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -38,7 +38,10 @@ module.exports = function(grunt) {
       custom_options: {
         options: {
           htmlFileName: 'index.html',
-          txtFileName: 'index.txt'
+          txtFileName: 'index.txt',
+          locals: {
+            name: 'Bobby'
+          }
         },
 
         files: {

--- a/README.md
+++ b/README.md
@@ -38,17 +38,24 @@ grunt.initConfig({
 
 #### htmlFileName
 
-Type: `String`  
+Type: `String`
 Default: `html.html`
 
 Name of output file with html content.
 
 #### txtFileName
 
-Type: `String`  
+Type: `String`
 Default: `text.txt`
 
 Name of output file with text content.
+
+#### locals
+
+Type: `Object`
+Default: `{}`
+
+Object with the variables used inside the templates.
 
 ### Usage Examples
 
@@ -67,14 +74,16 @@ grunt.initConfig({
 ```
 
 #### Custom filenames
-Template from *source/folder* will be handled by emails-template and saved
-in *target/folder* with file names index.html and text.txt.
+Template from *source/folder* will be handled by emails-template and saved in *target/folder* with file names index.html and text.txt. Data inside the `locals` object will also interpolate within the template (eg. `<%= name %>` into *Bobby*).
 
 ```js
 grunt.initConfig({
   email_templates: {
     options: {
-      htmlFileName: 'index.html'
+      htmlFileName: 'index.html',
+      locals: {
+        name: 'Bobby'
+      }
     },
     files: {
       'target/folder': 'source/folder'

--- a/tasks/email_templates.js
+++ b/tasks/email_templates.js
@@ -18,7 +18,8 @@ module.exports = function(grunt) {
     grunt.registerMultiTask('email_templates', 'Email templates task', function () {
         var options = this.options({
                 htmlFileName: 'html.html',
-                txtFileName: 'text.txt'
+                txtFileName: 'text.txt',
+                locals: {}
             }),
             done = this.async();
 
@@ -40,19 +41,19 @@ module.exports = function(grunt) {
             };
         }
 
-        function doCreateTemplate(folder, templateName) {
+        function doCreateTemplate(folder, templateName, options) {
             return function (next) {
                 emailTemplates(folder, function (err, template) {
                     if (err) {
                         return next(err);
                     }
 
-                    template(templateName, {}, next);
+                    template(templateName, options.locals, next);
                 });
             };
         }
 
-        function doExporMailTemplate(dest, options) {
+        function doExportMailTemplate(dest, options) {
             return function (html, text, next) {
                 async.parallel([
                     doWriteFile(path.join(dest, options.htmlFileName), html),
@@ -72,8 +73,8 @@ module.exports = function(grunt) {
 
                 async.waterfall([
                     doMkdirp(dest),
-                    doCreateTemplate(folder, templateName),
-                    doExporMailTemplate(dest, options)
+                    doCreateTemplate(folder, templateName, options),
+                    doExportMailTemplate(dest, options)
                 ], cb);
             }, next);
         }, function (err) {

--- a/test/expected/template2/index.html
+++ b/test/expected/template2/index.html
@@ -6,5 +6,6 @@
 </head>
 <body>
     <h1 style="color: red;">Test mail</h1>
+    <p>Hi Bobby</p>
 </body>
 </html>

--- a/test/expected/template2/index.txt
+++ b/test/expected/template2/index.txt
@@ -1,1 +1,2 @@
 Test mail
+Hi Bobby

--- a/test/fixtures/template2/html.ejs
+++ b/test/fixtures/template2/html.ejs
@@ -6,5 +6,6 @@
 </head>
 <body>
     <h1>Test mail</h1>
+    <p>Hi <%= name %></p>
 </body>
 </html>

--- a/test/fixtures/template2/text.ejs
+++ b/test/fixtures/template2/text.ejs
@@ -1,1 +1,2 @@
 Test mail
+Hi <%= name %>


### PR DESCRIPTION
Hey,

While creating email templates, I was using this Grunt task with a server, a watcher and live reload to set up an development environment for email templates. However, our templates happens to contain lots of variables to interpolate inside the template, I didn't find any cleaner way to introduce them into the template via this Grunt task except sending in a `locals` object with it.

Let me know what you think :smile: 
